### PR TITLE
adding dynamic metrics endpoint config

### DIFF
--- a/roles/deprovision-prometheus-apb/tasks/main.yml
+++ b/roles/deprovision-prometheus-apb/tasks/main.yml
@@ -21,6 +21,11 @@
     namespace: '{{ namespace }}'
     state: absent
 
+- k8s_v1_config_map:
+    name: grafana-dashboards-configmap
+    namespace: '{{ namespace }}'
+    state: absent
+
 - k8s_v1_service_account:
     name: oauth-proxy
     namespace: '{{ namespace }}'

--- a/roles/provision-prometheus-apb/templates/prometheus-config-map.yml.j2
+++ b/roles/provision-prometheus-apb/templates/prometheus-config-map.yml.j2
@@ -17,12 +17,11 @@ scrape_configs:
       namespaces:
         names:
           - {{ namespace }}
-    metrics_path: /metrics
     relabel_configs: 
       - action: keep
-        regex: ssl
+        regex: \/.*
         source_labels: 
-          - __meta_kubernetes_service_annotation_org_feedhenry_mcp_prometheus
+          - __meta_kubernetes_service_annotation_org_aerogear_metrics_ssl_endpoint
       - source_labels: 
           - __address__
         target_label: __param_target
@@ -37,6 +36,9 @@ scrape_configs:
       - source_labels: 
           - __meta_kubernetes_service_name
         target_label: kubernetes_name
+      - source_labels: [__meta_kubernetes_service_annotation_org_aerogear_metrics_ssl_endpoint]
+        regex: (.+)
+        target_label: __metrics_path__
 
   - job_name: mcp-plain-services
     scheme: http
@@ -45,12 +47,11 @@ scrape_configs:
       namespaces:
         names:
           - {{ namespace }}
-    metrics_path: /metrics
     relabel_configs: 
       - action: keep
-        regex: plain
+        regex: \/.*
         source_labels:
-          - __meta_kubernetes_service_annotation_org_feedhenry_mcp_prometheus
+          - __meta_kubernetes_service_annotation_org_aerogear_metrics_plain_endpoint
       - source_labels: 
           - __address__
         target_label: __param_target
@@ -65,3 +66,6 @@ scrape_configs:
       - source_labels: 
           - __meta_kubernetes_service_name
         target_label: kubernetes_name
+      - source_labels: [__meta_kubernetes_service_annotation_org_aerogear_metrics_plain_endpoint]
+        regex: (.+)
+        target_label: __metrics_path__


### PR DESCRIPTION
Allow the metrics end-point to be defined in the annotation.

Also, add a missed configmap to the deprovision playbook.